### PR TITLE
fix loss differentiation

### DIFF
--- a/Sources/DeepLearning/Loss.swift
+++ b/Sources/DeepLearning/Loss.swift
@@ -17,7 +17,7 @@ import TensorFlow
 #endif
 
 @differentiable
-public func meanSquaredError<Scalar: FloatingPoint>(
+public func meanSquaredError<Scalar: Differentiable & FloatingPoint>(
     predicted: Tensor<Scalar>, expected: Tensor<Scalar>) -> Tensor<Scalar> {
     return (expected - predicted).squared().mean()
 }


### PR DESCRIPTION
Compiling the TensorFlow lib in the standard library is failing with:
```
/swift-base/tensorflow-swift-apis/Sources/DeepLearning/Loss.swift:22:22: note: function call is not differentiable because generic requirements are not met
    return (expected - predicted).squared().mean()
```